### PR TITLE
patched to avoid crash with new js3 update

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ function setNameInstanceAdapter(name) {
 
     let instanceName = adapter.name + '.' + adapter.instance;
 
-    adapter.objects.getObject(instanceName, function (err, obj) {
+    adapter.objects(instanceName, function (err, obj) {
         if(err) return adapter.log.error(err), false;
         
         obj.common.name = name;

--- a/main.js
+++ b/main.js
@@ -56,10 +56,10 @@ function setNameInstanceAdapter(name) {
 
     let instanceName = adapter.name + '.' + adapter.instance;
 
-    adapter.objects(instanceName, function (err, obj) {
+    adapter.getObject(instanceName, function (err, obj) {
         if(err) return adapter.log.error(err), false;
         
         obj.common.name = name;
-        adapter.objects(instanceName, obj);
+        adapter.setObject(instanceName, obj);
     });
 }

--- a/main.js
+++ b/main.js
@@ -60,6 +60,6 @@ function setNameInstanceAdapter(name) {
         if(err) return adapter.log.error(err), false;
         
         obj.common.name = name;
-        adapter.objects.setObject(instanceName, obj);
+        adapter.objects(instanceName, obj);
     });
 }


### PR DESCRIPTION
Adapter crashed since some update to iobroker. Caused from a syntax change in js3.